### PR TITLE
feat: make the DeletePopup reusable for course deletion in CourseCard

### DIFF
--- a/src/components/ui/popups/delete_popup.tsx
+++ b/src/components/ui/popups/delete_popup.tsx
@@ -1,10 +1,22 @@
-import React from "react";
+import React, {ReactNode} from "react";
 
 interface DeletePopupProps {
+  onConfirm: () => void;
   onClose: () => void;
+  title?: string; 
+  message?: string | ReactNode;
+  confirmText?: string; 
+  cancelText?: string;
 }
 
-const DeletePopup: React.FC<DeletePopupProps> = ({ onClose }) => {
+const DeletePopup: React.FC<DeletePopupProps> = ({
+  onClose,
+  onConfirm,
+  title = "Delete Item",
+  message = "Are you sure you want to delete this item?",
+  confirmText = "Delete",
+  cancelText = "Cancel",
+}) => {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/25 backdrop-blur-sm z-50 px-4">
       <div className="w-full max-w-md sm:max-w-xl md:max-w-xl bg-rose-200 rounded-3xl shadow-[7px_7px_7px_rgba(0,0,0,1.00)] outline outline-4 outline-offset-[-2px] outline-black">
@@ -16,43 +28,41 @@ const DeletePopup: React.FC<DeletePopupProps> = ({ onClose }) => {
             <div className="w-3 h-3 bg-black/50 rounded-full" />
           </div>
           <span className="text-black text-xl sm:text-2xl md:text-3xl font-semibold font-['Poppins'] text-center flex-1">
-            Delete Saved Timetable
+            {title}
           </span>
-          
         </div>
 
         {/* Content */}
         <div className="text-center mt-6 px-4 py-4">
-          <p className="text-black  md:text-2xl font-normal font-['Poppins'] leading-relaxed">
-           Are you sure you want to delete this timetable?<br />‘evening theory’
+          <p className="text-black md:text-2xl font-normal font-['Poppins'] leading-relaxed">
+            {message}
           </p>
         </div>
 
+        {/* Buttons */}
+        <div className="flex justify-center gap-14 mt-6 px-4 py-4">
+          <button
+            onClick={onClose}
+            className="flex items-center justify-center gap-4 px-6 py-3 bg-amber-200 rounded-3xl shadow-[5px_5px_0px_rgba(0,0,0,1.00)] outline outline-4 outline-black"
+          >
+            <span className="text-black text-lg sm:text-xl md:text-2xl font-bold font-['Poppins']">
+              {cancelText}
+            </span>
+          </button>
 
-        {/* Cancel + Delete Buttons Side-by-Side */}
-<div className="flex justify-center gap-14 mt-6 px-4 py-4">
-  <button 
-    onClick={onClose}
-    className="flex items-center justify-center gap-4 px-6 py-3 bg-amber-200 rounded-3xl shadow-[5px_5px_0px_rgba(0,0,0,1.00)] outline outline-4 outline-black">
-    <span className="text-black text-lg sm:text-xl md:text-2xl font-bold font-['Poppins']">
-      Cancel
-    </span>
-  </button>
+          <button
+            onClick={onConfirm}
+            className="flex items-center justify-center gap-4 px-6 py-3 bg-rose-400 rounded-3xl shadow-[5px_5px_0px_rgba(0,0,0,1.00)] outline outline-4 outline-black"
+          >
+            <span className="text-black text-lg sm:text-xl md:text-2xl font-bold font-['Poppins']">
+              {confirmText}
+            </span>
+          </button>
+        </div>
 
-  <button 
-    onClick={onClose}
-    className="flex items-center justify-center gap-4 px-6 py-3 bg-rose-400 rounded-3xl shadow-[5px_5px_0px_rgba(0,0,0,1.00)] outline outline-4 outline-black">
-    <span className="text-black text-lg sm:text-xl md:text-2xl font-bold font-['Poppins']">
-      Delete
-    </span>
-  </button>
-</div>
-
-        {/* Bottom Padding */}
         <div className="h-6" />
       </div>
     </div>
   );
 };
-
 export default DeletePopup;


### PR DESCRIPTION

![localhost_3000_](https://github.com/user-attachments/assets/9ee997f9-0082-436c-a46f-69664a5a6c5b)

![localhost_3000_ (1)](https://github.com/user-attachments/assets/320fb06b-8543-4c6e-9f3b-2ef605741cd5)


1. Added some props inside the delete pop-up component to make it reusable as per scenarios with some default values as well

2. Integrated this component to CourseCard's delete button wherein a customised pop-up message with course name is prompted

_(screenshot attached above)_