### PR TITLE
Refactor: Cached Mongo and Used Pooling 

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,7 +7,7 @@ declare global {
   };
 }
 
-let globalWithMongoose = global as typeof globalThis & {
+const globalWithMongoose = global as typeof globalThis & {
   mongooseConnection: {
     conn: typeof mongoose | null;
     promise: Promise<typeof mongoose> | null;


### PR DESCRIPTION
This PR refactors the dbConnect function to support serverless environments like Vercel more efficiently.

Changes:
Implements global caching for the MongoDB connection using globalThis

Adds connection promise caching to prevent parallel connection attempts

Removes deprecated Mongoose options