### PR TITLE
Allow selecting of all components

### DIFF
--- a/src/app/four04/four04-mobile.tsx
+++ b/src/app/four04/four04-mobile.tsx
@@ -9,7 +9,7 @@ export default function NotFound() {
   const router = useRouter();
 
   return (
-    <div className="flex flex-col min-h-screen relative select-none">
+    <div className="flex flex-col min-h-screen relative">
       <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
         <Image
           src="/art/bg_dots.svg"
@@ -35,7 +35,7 @@ export default function NotFound() {
         <div className="relative w-fit h-fit mb-4">
           {/*Shadow*/}
           <span
-            className="absolute left-1.5 top-1.5 select-none pointer-events-none font-poppins font-extrabold text-[96px] z-0 text-black"
+            className="absolute left-1.5 top-1.5 pointer-events-none font-poppins font-extrabold text-[96px] z-0 text-black"
             style={{
               WebkitTextStroke: "8px black",
             }}
@@ -44,7 +44,7 @@ export default function NotFound() {
           </span>
           {/*Stroke*/}
           <span
-            className="absolute left-0 top-0 select-none pointer-events-none font-poppins font-extrabold text-[96px] z-10 text-transparent"
+            className="absolute left-0 top-0 pointer-events-none font-poppins font-extrabold text-[96px] z-10 text-transparent"
             style={{
               WebkitTextStroke: "8px black",
             }}
@@ -52,7 +52,7 @@ export default function NotFound() {
             404
           </span>
           {/*Fill*/}
-          <span className="relative select-none pointer-events-none font-poppins font-extrabold text-[96px] z-20 text-[#90BDFF]">
+          <span className="relative pointer-events-none font-poppins font-extrabold text-[96px] z-20 text-[#90BDFF]">
             404
           </span>
         </div>

--- a/src/app/four04/four04.tsx
+++ b/src/app/four04/four04.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/navigation";
 export default function NotFound() {
   const router = useRouter();
   return (
-    <div className="flex flex-col min-h-screen relative select-none">
+    <div className="flex flex-col min-h-screen relative">
       <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
         <Image
           src="/art/bg_dots.svg"
@@ -30,7 +30,7 @@ export default function NotFound() {
         <div className="relative w-fit h-fit mb-4">
           {/* Shadow */}
           <span
-            className="absolute left-2 top-2 select-none pointer-events-none font-poppins font-extrabold text-[160px] z-0 text-black"
+            className="absolute left-2 top-2 pointer-events-none font-poppins font-extrabold text-[160px] z-0 text-black"
             style={{
               WebkitTextStroke: "16px black",
             }}
@@ -39,7 +39,7 @@ export default function NotFound() {
           </span>
           {/* Stroke */}
           <span
-            className="absolute left-0 top-0 select-none pointer-events-none font-poppins font-extrabold text-[160px] z-10 text-transparent"
+            className="absolute left-0 top-0 pointer-events-none font-poppins font-extrabold text-[160px] z-10 text-transparent"
             style={{
               WebkitTextStroke: "16px black",
             }}
@@ -47,7 +47,7 @@ export default function NotFound() {
             404
           </span>
           {/* Fill */}
-          <span className="relative select-none pointer-events-none font-poppins font-extrabold text-[160px] z-20 text-[#90BDFF]">
+          <span className="relative pointer-events-none font-poppins font-extrabold text-[160px] z-20 text-[#90BDFF]">
             404
           </span>
         </div>

--- a/src/app/landing/landing-mobile.tsx
+++ b/src/app/landing/landing-mobile.tsx
@@ -27,7 +27,7 @@ export default function View() {
         />
       )}
 
-      <div className="flex flex-col min-h-screen relative select-none">
+      <div className="flex flex-col min-h-screen relative">
         <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
           <Image
             src="/art/bg_dots.svg"
@@ -55,7 +55,6 @@ export default function View() {
               alt="FFCS Logo"
               width={120}
               height={120}
-              className="select-none"
               unselectable="on"
               draggable={false}
               priority

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -78,7 +78,7 @@ export default function RootLayout({
         </Script>
       </head>
       <body
-        className={`${pangolin.variable} ${poppins.variable} ${inter.variable} antialiased bg-[#CEE4E5] select-none`}
+        className={`${pangolin.variable} ${poppins.variable} ${inter.variable} antialiased bg-[#CEE4E5]`}
       >
         <SessionProviderWrapper>{children}</SessionProviderWrapper>
         <ServiceWorkerRegister />

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -5,7 +5,7 @@ import Footer from "@/components/ui/Footer";
 
 export default function OfflinePage() {
   return (
-    <div className="flex flex-col min-h-screen relative select-none">
+    <div className="flex flex-col min-h-screen relative">
       <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
         <Image
           src="/art/bg_dots.svg"

--- a/src/app/saved/saved.tsx
+++ b/src/app/saved/saved.tsx
@@ -150,7 +150,7 @@ export default function Saved() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen relative select-none">
+    <div className="flex flex-col min-h-screen relative">
       <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
         <Image
           src="/art/bg_dots.svg"

--- a/src/app/share/[shareId]/shared.tsx
+++ b/src/app/share/[shareId]/shared.tsx
@@ -116,7 +116,7 @@ export default function SharedTimetablePage() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen relative select-none">
+    <div className="flex flex-col min-h-screen relative">
       <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
         <Image
           src="/art/bg_dots.svg"

--- a/src/app/slots/slots.tsx
+++ b/src/app/slots/slots.tsx
@@ -39,7 +39,7 @@ export default function View() {
   const lSlotPairsCol2 = lSlotPairs.slice(15);
 
   return (
-    <div className="flex flex-col min-h-screen relative select-none">
+    <div className="flex flex-col min-h-screen relative">
       {/* Background Image */}
       <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
         <Image

--- a/src/components/ui/Buttons.tsx
+++ b/src/components/ui/Buttons.tsx
@@ -132,7 +132,7 @@ export function CCButton() {
         alt="CC Button"
         width={80}
         height={80}
-        className="cursor-pointer select-none"
+        className="cursor-pointer"
         unselectable="on"
         draggable={false}
         priority
@@ -149,7 +149,7 @@ export function FFCSButton() {
       alt="FFCS Button"
       width={80}
       height={80}
-      className="cursor-pointer select-none"
+      className="cursor-pointer"
       onClick={() => router.push("/")}
       unselectable="on"
       draggable={false}
@@ -281,7 +281,7 @@ export function BasicToggleButton({
         w-[60px]
         h-[36px]
         rounded-[12px]
-        select-none
+       
         cursor-pointer
         font-poppins
         active:shadow-[2px_2px_0_0_black]

--- a/src/components/ui/CompoundTable.tsx
+++ b/src/components/ui/CompoundTable.tsx
@@ -40,7 +40,7 @@ export default function CompoundTable({ data, large }: CompoundTableProps) {
   });
 
   return (
-    <div className="flex flex-col lg:flex-row gap-4 m-2 text-black text-sm font-inter select-none lg:overflow-x-auto">
+    <div className="flex flex-col lg:flex-row gap-4 m-2 text-black text-sm font-inter lg:overflow-x-auto">
       <div className="overflow-x-auto lg:overflow-x-visible">
         <div
           className={`

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -98,7 +98,7 @@ export default function Footer({ type }: { type?: "desktop" | "mobile" }) {
   }
 
   return (
-    <footer className="w-full bg-[#CEE4E5] font-[poppins] text-black relative overflow-hidden flex items-center flex-col select-none">
+    <footer className="w-full bg-[#CEE4E5] font-[poppins] text-black relative overflow-hidden flex items-center flex-col">
       <div className="px-8 py-8 sm:py-6 xs:py-4 flex flex-col md:flex-row items-start justify-between relative z-10 w-full bg-[#A7D5D7] border-t-2 border-black gap-y-6">
         <div>
           <h2 className="text-6xl font-normal mb-4 font-[pangolin] md:text-4xl lg:text-6xl">

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -11,7 +11,7 @@ export default function Hero() {
         alt=""
         width={96}
         height={96}
-        className="mx-auto w-24 h-24 md:w-32 md:h-32 mb-6 select-none"
+        className="mx-auto w-24 h-24 md:w-32 md:h-32 mb-6"
         unselectable="on"
         draggable={false}
         priority
@@ -42,7 +42,6 @@ export default function Hero() {
         src="/art/art_rice.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -54,7 +53,6 @@ export default function Hero() {
         src="/art/art_boom.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -66,7 +64,6 @@ export default function Hero() {
         src="/art/art_paper.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -78,7 +75,6 @@ export default function Hero() {
         src="/art/art_plane.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -90,7 +86,6 @@ export default function Hero() {
         src="/art/letter_c.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -102,7 +97,6 @@ export default function Hero() {
         src="/art/letter_h.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -114,7 +108,6 @@ export default function Hero() {
         src="/art/letter_e.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -126,7 +119,6 @@ export default function Hero() {
         src="/art/letter_f.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -138,7 +130,6 @@ export default function Hero() {
         src="/art/letter_i.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -150,7 +141,6 @@ export default function Hero() {
         src="/art/letter_m.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority
@@ -162,7 +152,6 @@ export default function Hero() {
         src="/art/letter_k.svg"
         alt="graphic element"
         fill
-        className="select-none"
         unselectable="on"
         draggable={false}
         priority

--- a/src/components/ui/LoadingPopup.tsx
+++ b/src/components/ui/LoadingPopup.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export default function LoadingPopup({ isLoading }: { isLoading: boolean }) {
   if (!isLoading) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#425D5F]/75 backdrop-blur-xs select-none">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#425D5F]/75 backdrop-blur-xs">
       <div className="inline-flex flex-col rounded-3xl outline-4 outline-black shadow-[10px_10px_0_0_black] box-border items-center justify-center h-48 w-48 bg-[#A7D5D7]">
         <div
           className="w-16 h-16 animate-spin rounded-full mx-auto"

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -48,7 +48,7 @@ export default function Navbar({ page }: NavbarProps) {
         />
       )}
 
-      <div className="absolute top-0 left-0 w-full z-10 select-none">
+      <div className="absolute top-0 left-0 w-full z-10">
         <div className="flex justify-between items-center p-4">
           <div className="flex gap-4 items-center">
             {(page === "landing" || page === "404" || page === "placeholder") && (

--- a/src/components/ui/Popup.tsx
+++ b/src/components/ui/Popup.tsx
@@ -118,7 +118,7 @@ export default function Popup({
 
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-[#425D5F]/75 backdrop-blur-xs z-50 select-none">
+    <div className="fixed inset-0 flex items-center justify-center bg-[#425D5F]/75 backdrop-blur-xs z-50">
      
       {type === "share_tt" && isLoading && <LoadingPopup isLoading={true} />}
       <div
@@ -210,7 +210,6 @@ export default function Popup({
                   alt="artwork1"
                   width={32}
                   height={32}
-                  className="select-none"
                   unselectable="on"
                   draggable={false}
                   priority
@@ -222,7 +221,6 @@ export default function Popup({
                   alt="artwork2"
                   width={36}
                   height={36}
-                  className="select-none"
                   unselectable="on"
                   draggable={false}
                   priority
@@ -234,7 +232,6 @@ export default function Popup({
                   alt="artwork3"
                   width={72}
                   height={72}
-                  className="select-none"
                   unselectable="on"
                   draggable={false}
                   priority
@@ -246,7 +243,6 @@ export default function Popup({
                   alt="artwork4"
                   width={60}
                   height={60}
-                  className="select-none"
                   unselectable="on"
                   draggable={false}
                   priority

--- a/src/components/ui/PopupMobile.tsx
+++ b/src/components/ui/PopupMobile.tsx
@@ -30,7 +30,7 @@ type PopupLoginProps = {
 export function PopupLogin({ closeLink, onLoginClick }: PopupLoginProps) {
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto bg-white">
-      <div className="flex flex-col min-h-screen relative select-none">
+      <div className="flex flex-col min-h-screen relative">
         <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
           <Image
             src="/art/bg_dots.svg"
@@ -86,7 +86,6 @@ export function PopupLogin({ closeLink, onLoginClick }: PopupLoginProps) {
                 alt="artwork1"
                 width={32}
                 height={32}
-                className="select-none"
                 unselectable="on"
                 draggable={false}
                 priority
@@ -98,7 +97,6 @@ export function PopupLogin({ closeLink, onLoginClick }: PopupLoginProps) {
                 alt="artwork2"
                 width={36}
                 height={36}
-                className="select-none"
                 unselectable="on"
                 draggable={false}
                 priority
@@ -110,7 +108,6 @@ export function PopupLogin({ closeLink, onLoginClick }: PopupLoginProps) {
                 alt="artwork3"
                 width={72}
                 height={72}
-                className="select-none"
                 unselectable="on"
                 draggable={false}
                 priority
@@ -122,7 +119,6 @@ export function PopupLogin({ closeLink, onLoginClick }: PopupLoginProps) {
                 alt="artwork4"
                 width={60}
                 height={60}
-                className="select-none"
                 unselectable="on"
                 draggable={false}
                 priority

--- a/src/components/ui/TimeTable.tsx
+++ b/src/components/ui/TimeTable.tsx
@@ -127,7 +127,7 @@ export default function TimeTable({
 
   return (
     <div
-      className="grid bg-black relative w-full h-full p-[1px] select-none font-inter"
+      className="grid bg-black relative w-full h-full p-[1px] font-inter"
       style={{ gridTemplateColumns, gridTemplateRows }}
     >
       {cells}
@@ -140,7 +140,7 @@ export default function TimeTable({
           alt="logo of FFCS Platform by CodeChef-VIT"
           width={120}
           height={80}
-          className="w-auto h-2/3 block opacity-90 select-none pointer-events-none"
+          className="w-auto h-2/3 block opacity-90 pointer-events-none"
           draggable={false}
           unselectable="on"
           priority


### PR DESCRIPTION
Remove the disabling of selecting components.
Example Usecase:
Selecting the Course Code or Course Slot on the timetable share page to search it up
