### PR TITLE
Fixes #213 : phone layout and add missing rename/delete actions

### DIFF
--- a/src/app/saved/saved-mobile.tsx
+++ b/src/app/saved/saved-mobile.tsx
@@ -45,6 +45,8 @@ export default function SavedMobile() {
   const [popupTitle, setPopupTitle] = useState<string>('');
   const [selectedTT, setSelectedTT] = useState<TimetableEntry | null>(null);
   const [publicToggle, setPublicToggle] = useState(true);
+  // NEW: for rename support
+  const [renameValue, setRenameValue] = useState('');
 
   useEffect(() => {
     if (!userEmail) return;
@@ -72,11 +74,29 @@ export default function SavedMobile() {
     setShowPopup(true);
   }
 
+  // NEW: delete handler (mirrors saved.tsx)
+  async function handleDelete() {
+    if (!selectedTT) return;
+    await axios.delete(`/api/timetables/${selectedTT._id}`);
+    setTimetables(prev => prev.filter(t => t._id !== selectedTT._id));
+    setShowPopup(false);
+    setSelectedTT(null);
+  }
+
+  // NEW: rename handler (mirrors saved.tsx)
+  async function handleRename() {
+    if (!selectedTT) return;
+    await axios.patch(`/api/timetables/${selectedTT._id}`, { title: renameValue });
+    setTimetables(prev =>
+      prev.map(t => (t._id === selectedTT._id ? { ...t, title: renameValue } : t))
+    );
+    setShowPopup(false);
+    setSelectedTT(null);
+  }
+
   async function handleCopyLink(tt: TimetableEntry) {
     try {
-      await axios.patch(`/api/timetables/${tt._id}`, {
-        isPublic: publicToggle,
-      });
+      await axios.patch(`/api/timetables/${tt._id}`, { isPublic: publicToggle });
       const res = await axios.get(`/api/timetables/${tt._id}`);
       const updated = res.data;
       if (!updated.shareId) throw new Error('No shareId found');
@@ -88,9 +108,7 @@ export default function SavedMobile() {
   async function handleTogglePublic(state: 'on' | 'off') {
     if (!selectedTT) return;
     setPublicToggle(state === 'on');
-    await axios.patch(`/api/timetables/${selectedTT._id}`, {
-      isPublic: state === 'on',
-    });
+    await axios.patch(`/api/timetables/${selectedTT._id}`, { isPublic: state === 'on' });
     setTimetables(prev =>
       prev.map(tt => (tt._id === selectedTT._id ? { ...tt, isPublic: state === 'on' } : tt))
     );
@@ -98,6 +116,7 @@ export default function SavedMobile() {
 
   return (
     <div className="flex flex-col min-h-screen relative items-center font-poppins">
+      {/* Background */}
       <div className="absolute inset-0 -z-10 bg-[#CEE4E5]">
         <Image
           src="/art/bg_dots.svg"
@@ -113,43 +132,84 @@ export default function SavedMobile() {
 
       <Navbar page="mobile" />
 
-      <div className="text-4xl mb-8 mt-28 text-black font-pangolin">Saved Timetables</div>
+      {/* FIX: reduced mt-28 → mt-20 so title isn't pushed too far down on short phones */}
+      <div className="text-4xl mb-8 mt-20 text-black font-pangolin">Saved Timetables</div>
 
-      <ul className="w-full space-y-4 px-6">
-        {timetables.map((tt, index) => (
-          <li
-            key={tt._id}
-            className="grid grid-cols-[auto_1fr] items-center px-3 py-3 bg-[#A7D5D7] text-black rounded-xl border-2 border-black shadow-[2px_2px_0_0_black]"
-            onClick={() => handleView(tt)}
-          >
-            <span className="font-medium text-base mr-4">{index + 1}.</span>
-            <span className="font-medium text-base truncate">{tt.title}</span>
-          </li>
-        ))}
-      </ul>
-
-      <div className="flex items-center w-full mt-8 mb-8 text-sm font-poppins font-semibold text-black/50 px-8">
-        <div className="flex-grow h-0.5 bg-gradient-to-r from-transparent to-black/33" />
-        {loading ? null : timetables.length === 0 ? (
-          <span className="mx-4">Nothing To Show Here</span>
-        ) : (
-          <span className="mx-4">End of List</span>
-        )}
-        <div className="flex-grow h-0.5 bg-gradient-to-r from-black/33 to-transparent" />
-      </div>
-
+      {/* FIX: unified loading/empty/list rendering — no orphaned divider during load */}
       {loading ? (
-        <Loader />
-      ) : timetables.length === 0 ? (
-        <div className="mx-auto my-auto text-center text-sm font-poppins font-semibold text-black/70">
-          No saved timetables found.
-          <br />
-          Create and save from the desktop website.
+        <div className="flex-1 flex items-center justify-center">
+          <Loader />
         </div>
-      ) : null}
+      ) : timetables.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center px-8">
+          <p className="text-center text-sm font-semibold text-black/70">
+            No saved timetables found.
+            <br />
+            Create and save from the desktop website.
+          </p>
+        </div>
+      ) : (
+        <>
+          <ul className="w-full space-y-4 px-6">
+            {timetables.map((tt, index) => (
+              <li
+                key={tt._id}
+                className="grid grid-cols-[auto_1fr_auto] items-center px-3 py-3 bg-[#A7D5D7] text-black rounded-xl border-2 border-black shadow-[2px_2px_0_0_black] active:opacity-70 transition-opacity"
+              >
+                {/* Tapping the number or title opens the view popup */}
+                <span
+                  className="font-medium text-base mr-4"
+                  onClick={() => handleView(tt)}
+                >
+                  {index + 1}.
+                </span>
+                <span
+                  className="font-medium text-base truncate"
+                  onClick={() => handleView(tt)}
+                >
+                  {tt.title}
+                </span>
+
+                {/* NEW: action buttons for rename and delete on mobile */}
+                <div className="flex gap-2 ml-2" onClick={e => e.stopPropagation()}>
+                  <button
+                    className="p-1 rounded-lg bg-blue-200 border border-black text-xs font-semibold"
+                    onClick={() => {
+                      setSelectedTT(tt);
+                      setRenameValue(tt.title);
+                      setPopupType('rename_tt');
+                      setShowPopup(true);
+                    }}
+                  >
+                    ✏️
+                  </button>
+                  <button
+                    className="p-1 rounded-lg bg-red-200 border border-black text-xs font-semibold"
+                    onClick={() => {
+                      setSelectedTT(tt);
+                      setPopupType('delete_tt');
+                      setShowPopup(true);
+                    }}
+                  >
+                    🗑️
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          {/* Divider only shown when list is visible */}
+          <div className="flex items-center w-full mt-8 mb-8 text-sm font-poppins font-semibold text-black/50 px-8">
+            <div className="flex-grow h-0.5 bg-gradient-to-r from-transparent to-black/33" />
+            <span className="mx-4">End of List</span>
+            <div className="flex-grow h-0.5 bg-gradient-to-r from-black/33 to-transparent" />
+          </div>
+        </>
+      )}
 
       <Footer type="mobile" />
 
+      {/* View popup — unchanged */}
       {showPopup && popupType === 'view_tt' && selectedTT && (
         <PopupViewTT
           TTName={popupTitle}
@@ -160,12 +220,63 @@ export default function SavedMobile() {
           shareSwitchAction={handleTogglePublic}
           shareLink={
             selectedTT.shareId
-              ? `${
-                  typeof window !== 'undefined' ? window.location.origin : ''
-                }/share/${selectedTT.shareId}`
+              ? `${typeof window !== 'undefined' ? window.location.origin : ''}/share/${selectedTT.shareId}`
               : ''
           }
         />
+      )}
+
+      {/* NEW: delete confirmation popup */}
+      {showPopup && popupType === 'delete_tt' && selectedTT && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-6">
+          <div className="bg-white rounded-2xl border-2 border-black p-6 w-full max-w-sm shadow-[4px_4px_0_0_black]">
+            <p className="text-base font-semibold mb-4 text-center">
+              Delete &quot;{selectedTT.title}&quot;?
+            </p>
+            <div className="flex gap-3 justify-center">
+              <button
+                className="px-4 py-2 rounded-xl border-2 border-black bg-red-300 font-semibold active:opacity-70"
+                onClick={handleDelete}
+              >
+                Delete
+              </button>
+              <button
+                className="px-4 py-2 rounded-xl border-2 border-black bg-gray-100 font-semibold active:opacity-70"
+                onClick={() => setShowPopup(false)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* NEW: rename popup */}
+      {showPopup && popupType === 'rename_tt' && selectedTT && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-6">
+          <div className="bg-white rounded-2xl border-2 border-black p-6 w-full max-w-sm shadow-[4px_4px_0_0_black]">
+            <p className="text-base font-semibold mb-4 text-center">Rename Timetable</p>
+            <input
+              className="w-full border-2 border-black rounded-xl px-3 py-2 mb-4 text-sm font-poppins"
+              value={renameValue}
+              onChange={e => setRenameValue(e.target.value)}
+            />
+            <div className="flex gap-3 justify-center">
+              <button
+                className="px-4 py-2 rounded-xl border-2 border-black bg-blue-300 font-semibold active:opacity-70"
+                onClick={handleRename}
+              >
+                Save
+              </button>
+              <button
+                className="px-4 py-2 rounded-xl border-2 border-black bg-gray-100 font-semibold active:opacity-70"
+                onClick={() => setShowPopup(false)}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/app/saved/saved-mobile.tsx
+++ b/src/app/saved/saved-mobile.tsx
@@ -8,6 +8,8 @@ import Image from 'next/image';
 import axios from 'axios';
 import { PopupViewTT } from '@/components/ui/PopupMobile';
 import Loader from '@/components/ui/Loader';
+import Popup from '@/components/ui/Popup';
+import { ZButton } from '@/components/ui/Buttons';
 
 async function fetchTimetablesByOwner(owner: string) {
   const res = await axios.get(`/api/timetables?owner=${encodeURIComponent(owner)}`);
@@ -45,6 +47,7 @@ export default function SavedMobile() {
   const [popupTitle, setPopupTitle] = useState<string>('');
   const [selectedTT, setSelectedTT] = useState<TimetableEntry | null>(null);
   const [publicToggle, setPublicToggle] = useState(true);
+  
   // NEW: for rename support
   const [renameValue, setRenameValue] = useState('');
 
@@ -172,27 +175,27 @@ export default function SavedMobile() {
 
                 {/* NEW: action buttons for rename and delete on mobile */}
                 <div className="flex gap-2 ml-2" onClick={e => e.stopPropagation()}>
-                  <button
-                    className="p-1 rounded-lg bg-blue-200 border border-black text-xs font-semibold"
+                  <ZButton
+                    type="image"
+                    color="blue"
+                    image="/icons/edit.svg"
                     onClick={() => {
                       setSelectedTT(tt);
                       setRenameValue(tt.title);
                       setPopupType('rename_tt');
                       setShowPopup(true);
                     }}
-                  >
-                    ✏️
-                  </button>
-                  <button
-                    className="p-1 rounded-lg bg-red-200 border border-black text-xs font-semibold"
+                  />
+                  <ZButton
+                    type="image"
+                    color="red"
+                    image="/icons/trash.svg"
                     onClick={() => {
                       setSelectedTT(tt);
                       setPopupType('delete_tt');
                       setShowPopup(true);
                     }}
-                  >
-                    🗑️
-                  </button>
+                  />
                 </div>
               </li>
             ))}
@@ -226,58 +229,24 @@ export default function SavedMobile() {
         />
       )}
 
-      {/* NEW: delete confirmation popup */}
       {showPopup && popupType === 'delete_tt' && selectedTT && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-6">
-          <div className="bg-white rounded-2xl border-2 border-black p-6 w-full max-w-sm shadow-[4px_4px_0_0_black]">
-            <p className="text-base font-semibold mb-4 text-center">
-              Delete &quot;{selectedTT.title}&quot;?
-            </p>
-            <div className="flex gap-3 justify-center">
-              <button
-                className="px-4 py-2 rounded-xl border-2 border-black bg-red-300 font-semibold active:opacity-70"
-                onClick={handleDelete}
-              >
-                Delete
-              </button>
-              <button
-                className="px-4 py-2 rounded-xl border-2 border-black bg-gray-100 font-semibold active:opacity-70"
-                onClick={() => setShowPopup(false)}
-              >
-                Cancel
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+              <Popup
+                type="delete_tt"
+                dataBody={selectedTT.title}
+                closeLink={() => setShowPopup(false)}
+                action={handleDelete}
+              />
+            )}
 
-      {/* NEW: rename popup */}
-      {showPopup && popupType === 'rename_tt' && selectedTT && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-6">
-          <div className="bg-white rounded-2xl border-2 border-black p-6 w-full max-w-sm shadow-[4px_4px_0_0_black]">
-            <p className="text-base font-semibold mb-4 text-center">Rename Timetable</p>
-            <input
-              className="w-full border-2 border-black rounded-xl px-3 py-2 mb-4 text-sm font-poppins"
-              value={renameValue}
-              onChange={e => setRenameValue(e.target.value)}
-            />
-            <div className="flex gap-3 justify-center">
-              <button
-                className="px-4 py-2 rounded-xl border-2 border-black bg-blue-300 font-semibold active:opacity-70"
-                onClick={handleRename}
-              >
-                Save
-              </button>
-              <button
-                className="px-4 py-2 rounded-xl border-2 border-black bg-gray-100 font-semibold active:opacity-70"
-                onClick={() => setShowPopup(false)}
-              >
-                Cancel
-              </button>
+            {showPopup && popupType === 'rename_tt' && selectedTT && (
+              <Popup
+                type="rename_tt"
+                dataBody={renameValue}
+                closeLink={() => setShowPopup(false)}
+                action={handleRename}
+                onInputChange={setRenameValue}
+              />
+            )}
             </div>
-          </div>
-        </div>
-      )}
-    </div>
   );
 }

--- a/src/app/slots/slots.tsx
+++ b/src/app/slots/slots.tsx
@@ -177,9 +177,9 @@ export default function View() {
         )}
 
         {/* Timetable Section */}
-        <div className="w-full mt-12 mb-10 px-4">
+        <div className="mx-auto mt-12 mb-10 w-full max-w-[1000px]">
           <div className="overflow-x-auto">
-            <div className="min-w-[1000px]">
+            <div className="min-w-[1000px] h-[480px]">
               <TimeTable ... />
             </div>
           </div>

--- a/src/app/slots/slots.tsx
+++ b/src/app/slots/slots.tsx
@@ -177,15 +177,10 @@ export default function View() {
         )}
 
         {/* Timetable Section */}
-        <div className="mx-auto mt-12 mb-10 w-full max-w-[1000px]">
+        <div className="w-full mt-12 mb-10 px-4">
           <div className="overflow-x-auto">
-            <div className="min-w-[1000px] h-[480px]">
-              <TimeTable
-                slotNames={active.map(i => ({
-                  slotName: buttonTexts[i],
-                  showName: true,
-                }))}
-              />
+            <div className="min-w-[1000px]">
+              <TimeTable ... />
             </div>
           </div>
         </div>

--- a/src/components/ui/TimeTable.tsx
+++ b/src/components/ui/TimeTable.tsx
@@ -119,12 +119,8 @@ export default function TimeTable({ slotNames }: { slotNames: tableFacingSlot[] 
 
   return (
     <div
-      className="grid bg-black relative w-full p-[1px] select-none font-inter"
-      style={{
-        gridTemplateColumns,
-        gridTemplateRows,
-        aspectRatio: `${totalColWeight} / ${totalRowWeight}`,
-      }}
+      className="grid bg-black relative w-full h-full p-[1px] select-none font-inter"
+      style={{ gridTemplateColumns, gridTemplateRows }}
     >
       {cells}
       <div

--- a/src/components/ui/TimeTable.tsx
+++ b/src/components/ui/TimeTable.tsx
@@ -119,8 +119,12 @@ export default function TimeTable({ slotNames }: { slotNames: tableFacingSlot[] 
 
   return (
     <div
-      className="grid bg-black relative w-full h-full p-[1px] select-none font-inter"
-      style={{ gridTemplateColumns, gridTemplateRows }}
+      className="grid bg-black relative w-full p-[1px] select-none font-inter"
+      style={{
+        gridTemplateColumns,
+        gridTemplateRows,
+        aspectRatio: `${totalColWeight} / ${totalRowWeight}`,
+      }}
     >
       {cells}
       <div


### PR DESCRIPTION
### Problem

#213 

The saved timetables page had multiple issues on mobile:

1. **Missing rename and delete actions** — the mobile component had no way to rename or delete a saved timetable, while the desktop version (`saved.tsx`) supported both. This was the most impactful regression.
2. **Orphaned divider bar during loading** — the `End of List` divider rendered unconditionally, so a bare horizontal bar appeared on screen while timetables were still being fetched.
3. **Title overflow on short phones** — `mt-28` (112px) pushed the heading too far down on shorter devices, clipping content in some viewports.
4. **No tap feedback** — list items had no visual response on tap.

### Changes

- Added `handleDelete` and `handleRename` functions mirroring `saved.tsx` logic
- Added per-row ✏️ and 🗑️ buttons with inline modals for rename and delete
- Unified the loading / empty state / list into a single `if/else` block so the divider only renders when the list is visible
- Reduced title top margin from `mt-28` to `mt-20`
- Updated `<li>` grid to `grid-cols-[auto_1fr_auto]` to accommodate action buttons
- Scoped `onClick` to title/index spans to prevent button click conflicts
- Added `active:opacity-70 transition-opacity` tap feedback